### PR TITLE
Allow composing of Jigasi, Jibri and Etherpad containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ jitsi::containerized_server::disable_auto_gain_control: true
 jitsi::containerized_server::disable_high_pass_filter: true
 ```
 
+#### Starting additional containers
+
+You can add additional container to compose process (like Jigasi, Jibri and Etherpad) using these parameters:
+```
+jitsi::containerized_server::compose_jigasi: false
+jitsi::containerized_server::compose_jibri: false
+jitsi::containerized_server::compose_etherpad: false
+```
+
 ## Notes
 
 This is an experiment on how to handle standalone containerized applications.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -113,6 +113,9 @@ The following parameters are available in the `jitsi::containerized_server` clas
 * [`disable_simulcast`](#disable_simulcast)
 * [`require_display_name`](#require_display_name)
 * [`channel_last_n`](#channel_last_n)
+* [`compose_jigasi`](#compose_jigasi)
+* [`compose_jibri`](#compose_jibri)
+* [`compose_etherpad`](#compose_etherpad)
 
 ##### <a name="jicofo_component_secret"></a>`jicofo_component_secret`
 
@@ -313,4 +316,22 @@ Data type: `Integer`
 
 This value can help to save bandwidth on the server. If set to a positive integer,
 only this amount of videostreams is sent, representing the last N speakers.
+
+##### <a name="compose_jigasi"></a>`compose_jigasi`
+
+Data type: `Boolean`
+
+Compose and start Jigasi container, the SIP (audio only) gateway.
+
+##### <a name="compose_jibri"></a>`compose_jibri`
+
+Data type: `Boolean`
+
+Compose and start Jibri container, the broadcasting infrastructure.
+
+##### <a name="compose_etherpad"></a>`compose_etherpad`
+
+Data type: `Boolean`
+
+Compose and start Etherpad container, a real-time collaborative editor.
 

--- a/manifests/containerized_server.pp
+++ b/manifests/containerized_server.pp
@@ -116,6 +116,9 @@ class jitsi::containerized_server (
   Boolean $enable_simulcast,
   Boolean $require_display_name,
   Integer $channel_last_n,
+  Boolean $compose_jigasi,
+  Boolean $compose_jibri,
+  Boolean $compose_etherpad,
 ) {
   include docker
   include docker::compose

--- a/templates/jitsi.service.erb
+++ b/templates/jitsi.service.erb
@@ -8,7 +8,7 @@ User=root
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/srv/jitsi
-ExecStart=/usr/local/bin/docker-compose up -d --remove-orphans
+ExecStart=/usr/local/bin/docker-compose -f docker-compose.yml<% if @compose_jigasi == true -%> -f jigasi.yml <% end %><% if @compose_jibri == true -%> -f jibri.yml <% end %><% if @compose_etherpad == true -%> -f etherpad.yml <% end %>up -d --remove-orphans
 ExecStop=/usr/local/bin/docker-compose down
 
 [Install]


### PR DESCRIPTION
At the moment only docker-compose.yml is considered in systemd unit `jitsi`. I implemented a way to compose and start the containers for Jigasi, Jibri and Etherpad too. These are the additional containers that `docker-jitsi-meet` supports at the time of this writing.