### PR TITLE
Switch to Compose V2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
     },
     {
       "name": "puppetlabs/docker",
-      "version_requirement": ">= 3.13.1 < 5.0"
+      "version_requirement": ">= 10.0.0 < 11.0.0"
     },
     {
       "name": "puppet/systemd",

--- a/templates/jitsi.service.erb
+++ b/templates/jitsi.service.erb
@@ -8,13 +8,12 @@ User=root
 Type=oneshot
 RemainAfterExit=true
 WorkingDirectory=/srv/jitsi
-ExecStart=/usr/local/bin/docker-compose -f docker-compose.yml<% if @compose_jigasi == true -%>
+ExecStart=/usr/bin/docker compose -f docker-compose.yml<% if @compose_jigasi == true -%>
   -f jigasi.yml <% end %><% if @compose_jibri == true -%>
   -f jibri.yml <% end %><% if @compose_etherpad == true -%>
   -f etherpad.yml <% end -%>
   up -d --remove-orphans
-ExecStop=/usr/local/bin/docker-compose down
+ExecStop=/usr/bin/docker compose down
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Docker Compose V1 has stopped receiving updates [1] and should be replaced by V2. This PR aims to migrate to V2.

[1] https://docs.docker.com/compose/